### PR TITLE
Fix duplicate database filename error message

### DIFF
--- a/app/src/main/java/com/ivanovsky/passnotes/data/entity/OperationError.java
+++ b/app/src/main/java/com/ivanovsky/passnotes/data/entity/OperationError.java
@@ -157,11 +157,11 @@ public class OperationError implements Serializable {
     }
 
     public static OperationError newFileAlreadyExistsError(String message, Stacktrace stacktrace) {
-        return new OperationError(Type.FILE_IS_ALREADY_EXISTS, message, stacktrace);
+        return new OperationError(Type.FILE_ALREADY_EXISTS, message, stacktrace);
     }
 
     public static OperationError newFileAlreadyExistsError(Stacktrace stacktrace) {
-        return new OperationError(Type.FILE_IS_ALREADY_EXISTS, null, stacktrace);
+        return new OperationError(Type.FILE_ALREADY_EXISTS, null, stacktrace);
     }
 
     public static OperationError newCacheError(String message, Stacktrace stacktrace) {
@@ -203,7 +203,7 @@ public class OperationError implements Serializable {
         GENERIC_IO_ERROR,
         AUTH_ERROR,
         NETWORK_IO_ERROR,
-        FILE_IS_ALREADY_EXISTS,
+        FILE_ALREADY_EXISTS,
         // inconsistent cached data,
         CACHE_ERROR,
         REMOTE_API_ERROR,

--- a/app/src/main/kotlin/com/ivanovsky/passnotes/domain/interactor/newdb/NewDatabaseInteractor.kt
+++ b/app/src/main/kotlin/com/ivanovsky/passnotes/domain/interactor/newdb/NewDatabaseInteractor.kt
@@ -1,5 +1,6 @@
 package com.ivanovsky.passnotes.domain.interactor.newdb
 
+import com.ivanovsky.passnotes.R
 import com.ivanovsky.passnotes.data.entity.FileDescriptor
 import com.ivanovsky.passnotes.data.entity.OperationError.MESSAGE_DEFERRED_OPERATIONS_ARE_NOT_SUPPORTED
 import com.ivanovsky.passnotes.data.entity.OperationError.newFileAccessError
@@ -12,6 +13,7 @@ import com.ivanovsky.passnotes.data.repository.file.FileSystemResolver
 import com.ivanovsky.passnotes.data.repository.keepass.KeepassImplementation
 import com.ivanovsky.passnotes.data.repository.keepass.PasswordKeepassKey
 import com.ivanovsky.passnotes.domain.DispatcherProvider
+import com.ivanovsky.passnotes.domain.ResourceProvider
 import com.ivanovsky.passnotes.domain.entity.exception.Stacktrace
 import com.ivanovsky.passnotes.extensions.toUsedFile
 import kotlinx.coroutines.withContext
@@ -20,6 +22,7 @@ class NewDatabaseInteractor(
     private val dbRepo: EncryptedDatabaseRepository,
     private val usedFileRepository: UsedFileRepository,
     private val fileSystemResolver: FileSystemResolver,
+    private val resourceProvider: ResourceProvider,
     private val dispatchers: DispatcherProvider
 ) {
 
@@ -38,7 +41,14 @@ class NewDatabaseInteractor(
 
             val isExists = existsResult.obj
             if (isExists) {
-                return@withContext OperationResult.error(newFileAlreadyExistsError(Stacktrace()))
+                val message =
+                    resourceProvider.getString(R.string.file_already_exists_detailed, file.name)
+                return@withContext OperationResult.error(
+                    newFileAlreadyExistsError(
+                        message,
+                        Stacktrace()
+                    )
+                )
             }
 
             val creationResult = dbRepo.createNew(

--- a/app/src/main/kotlin/com/ivanovsky/passnotes/extensions/OperationErrorExt.kt
+++ b/app/src/main/kotlin/com/ivanovsky/passnotes/extensions/OperationErrorExt.kt
@@ -22,6 +22,10 @@ fun OperationError.formatReadableMessage(
             resourceProvider.getString(R.string.file_not_found)
         }
 
+        OperationError.Type.FILE_ALREADY_EXISTS -> {
+            resourceProvider.getString(R.string.file_already_exists)
+        }
+
         else -> null
     }
 

--- a/app/src/main/kotlin/com/ivanovsky/passnotes/injection/modules/UiModule.kt
+++ b/app/src/main/kotlin/com/ivanovsky/passnotes/injection/modules/UiModule.kt
@@ -126,7 +126,7 @@ object UiModule {
                 )
             }
             single { StorageListInteractor(get(), get(), get()) }
-            single { NewDatabaseInteractor(get(), get(), get(), get()) }
+            single { NewDatabaseInteractor(get(), get(), get(), get(), get()) }
             single { GroupEditorInteractor(get(), get(), get(), get(), get()) }
             single { DebugMenuInteractor(get(), get(), get(), get(), get()) }
             single {

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -71,7 +71,7 @@
     <string name="error_has_been_occurred">Трапилась помилка</string>
     <string name="network_error_message">Сталася помилка мережі, перевірте підключення до Інтернету</string>
     <string name="file_permission_error_message">Неможливо отримати доступ до файлу, надайте дозвіл для програми</string>
-    <string name="file_is_already_exist">Файл вже існує</string>
+    <string name="file_already_exists">Файл вже існує</string>
     <string name="empty_field">Порожнє поле</string>
     <string name="sync_conflict_message">Локальна та віддалена бази даних кофліктують. Будь ласка, вирішіть цей конфлікт.</string>
     <string name="sync_file_not_found_message">Не вдається знайти файл бази даних на віддаленому сервері. Спробуйте видалити цей файл і додати його знову.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -64,7 +64,7 @@
     <string name="error_has_been_occurred">发生错误</string>
     <string name="network_error_message">发生网络错误，请检查网络连接</string>
     <string name="file_permission_error_message">无法访问文件，请为应用授予文件权限</string>
-    <string name="file_is_already_exist">文件已存在</string>
+    <string name="file_already_exists">文件已存在</string>
     <string name="empty_field">字段不能为空</string>
     <string name="sync_conflict_message">本地数据库与远程数据库版本存在冲突，请先解决冲突再访问数据库。</string>
     <string name="sync_file_not_found_message">在远程服务器上找不到数据库文件，请尝试删除该文件后重新添加。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,7 +71,8 @@
     <string name="error_has_been_occurred">Error has been occurred</string>
     <string name="network_error_message">Network error has been occurred, check internet connection</string>
     <string name="file_permission_error_message">Unable to access to file, please provider permission for application</string>
-    <string name="file_is_already_exist">File is already exist</string>
+    <string name="file_already_exists">File already exists</string>
+    <string name="file_already_exists_detailed">File %s already exists</string>
     <string name="empty_field">Empty field</string>
     <string name="sync_conflict_message">There is a conflict between version of local and remote databases. Please resolve this conflict before accessing database.</string>
     <string name="sync_file_not_found_message">Unable to find database file on remote server. Please try to remove this file and add it again.</string>

--- a/app/src/main/res/values/untranslatable-strings.xml
+++ b/app/src/main/res/values/untranslatable-strings.xml
@@ -43,7 +43,6 @@
     <string name="failed_to_parse_test_data" translatable="false">Failed to parse test data</string>
     <string name="test_data_successfully_imported" translatable="false">Test data successfully imported</string>
     <string name="file_created_successfully" translatable="false">File created successfully</string>
-    <string name="file_already_exists" translatable="false">File already exists</string>
     <string name="test_data_removed" translatable="false">Test data removed</string>
     <string name="biometric_data_invalidated" translatable="false">Biometric data is invalidated</string>
     <string name="short_dummy_text" translatable="false">Lorem Ipsum is simply dummy.</string>


### PR DESCRIPTION
## Summary
- show a specific error when a new database filename already exists
- use translatable resources for the user-facing message
- correct the English message to `File already exists`

Closes #321