### PR TITLE
Add ACRA email crash reporting with user-consent dialog

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -310,6 +310,8 @@ dependencies {
     // Logging
     implementation(libs.timber)
     implementation(libs.treessence)
+    implementation(libs.acra.dialog)
+    implementation(libs.acra.mail)
 
     // KeePass
     implementation(libs.kotpass)

--- a/app/src/main/kotlin/com/ivanovsky/passnotes/App.kt
+++ b/app/src/main/kotlin/com/ivanovsky/passnotes/App.kt
@@ -7,6 +7,10 @@ import com.ivanovsky.passnotes.data.repository.settings.SettingsImpl
 import com.ivanovsky.passnotes.domain.logger.LoggerInteractor
 import com.ivanovsky.passnotes.injection.DIModuleBuilder
 import com.ivanovsky.passnotes.injection.DefaultModuleBuilder
+import org.acra.config.dialog
+import org.acra.config.mailSender
+import org.acra.data.StringFormat
+import org.acra.ktx.initAcra
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.startKoin
@@ -15,6 +19,30 @@ open class App : Application() {
 
     open fun configureModuleBuilder(builder: DIModuleBuilder) {
         // implementation should be flavor specific
+    }
+
+    override fun attachBaseContext(base: Context) {
+        super.attachBaseContext(base)
+
+        initAcra {
+            buildConfigClass = BuildConfig::class.java
+            reportFormat = StringFormat.KEY_VALUE_LIST
+
+            dialog {
+                title = getString(R.string.crash_report_dialog_title)
+                text = getString(R.string.crash_report_dialog_message)
+                positiveButtonText = getString(R.string.crash_report_dialog_send)
+                negativeButtonText = getString(R.string.cancel)
+                commentPrompt = getString(R.string.crash_report_dialog_comment)
+            }
+
+            mailSender {
+                mailTo = getString(R.string.crash_report_email)
+                reportAsFile = false
+                subject = getString(R.string.crash_report_email_subject)
+                body = getString(R.string.crash_report_email_body)
+            }
+        }
     }
 
     override fun onCreate() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -416,4 +416,11 @@
     <string name="go_to_issues">Go to issues</string>
     <string name="show_stacktrace">...Show stacktrace...</string>
 
+    <string name="crash_report_dialog_title">KeePassVault crashed</string>
+    <string name="crash_report_dialog_message">KeePassVault has encountered an unexpected error. You can review the crash report before sending or sharing it as plain text with another app.</string>
+    <string name="crash_report_dialog_send">Send report</string>
+    <string name="crash_report_dialog_comment">Optional: describe what you were doing before the crash</string>
+    <string name="crash_report_email_subject">KeePassVault crash report</string>
+    <string name="crash_report_email_body">Please review the crash report before sending it. It may include device and app diagnostics, but it should not include your database password or KeePass entries. You can also share this plain text report with another app from the chooser.</string>
+
 </resources>

--- a/app/src/main/res/values/untranslatable-strings.xml
+++ b/app/src/main/res/values/untranslatable-strings.xml
@@ -100,4 +100,5 @@
         <item>FUZZY</item>
     </string-array>
 
+    <string name="crash_report_email" translatable="false">alexei.ivanovski@gmail.com</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ liveDataKtx = "2.7.0"
 composeBom = "2026.01.01"
 composeIcons = "1.6.8"
 arrow = "2.1.2"
+acra = "5.13.1"
 
 okHttp = "4.12.0"
 apacheCommonsLang = "3.13.0"
@@ -121,3 +122,5 @@ fzf4j = { module = "com.github.aivanovski:fzf4j", version.ref = "fzf4j" }
 totp-kt = { module = "com.github.robinohs:totp-kt", version.ref = "totpKt" }
 arrowCore = { module = "io.arrow-kt:arrow-core", version.ref = "arrow" }
 arrowCoroutines = { module = "io.arrow-kt:arrow-fx-coroutines", version.ref = "arrow" }
+acra-dialog = { module = "ch.acra:acra-dialog", version.ref = "acra" }
+acra-mail = { module = "ch.acra:acra-mail", version.ref = "acra" }


### PR DESCRIPTION
### Motivation

- Provide in-app crash reporting so users can review and send crash reports via email or share them as plain text with other apps.

### Description

- Added ACRA dependency entries to the version catalog (`gradle/libs.versions.toml`) and declared the dialog and mail modules in `app/build.gradle.kts`.
- Initialized ACRA in `App.attachBaseContext(...)` using `initAcra {}` with a report format of `KEY_VALUE_LIST`, a consent dialog configuration, and `mailSender` configured to send the report inline (`reportAsFile = false`).
- Added user-facing strings for the crash dialog and email (`app/src/main/res/values/strings.xml`) and the support email in `untranslatable-strings.xml`.

### Testing

- Ran `git diff --check` and static diff checks which reported no problems.
- Ran `./gradlew app:spotlessApply` which failed due to environment/network limitation (dependency download returned HTTP 403 for `google-java-format`).
- Ran `./gradlew app:compileFdroidDebugKotlin` and `./gradlew test` which were blocked by a missing Android SDK in the environment (error: SDK location not found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4685f593348322b2d97b367023ac7e)